### PR TITLE
add missing GeForce RTX 2080 Rev. A

### DIFF
--- a/production.list
+++ b/production.list
@@ -60,6 +60,7 @@ Nvidia corporation device 2783
 Nvidia corporation device 2783 (rev a1)
 NVIDIA Corporation Device 2584 (rev a1)
 GeForce GTX 1070 Mobile 1BA1
+GeForce RTX 2080 Rev. A
 
 ##################################################
 # Driver provided names & ID's


### PR DESCRIPTION
```
Using automatic Nvidia driver detection
Detect if we have a Nvidia GPU
Detected a NVIDIA GPU
Checking card: GeForce RTX 2080 Rev. A with ID: 1E87
GeForce RTX 2080 Rev. A is not in any of the lists
Failing back to the OpenSource Mesa Nouveau driver
Using OpenSource Mesa Nouveau driver
```